### PR TITLE
Add lite mode

### DIFF
--- a/resources/config/dbmask.php
+++ b/resources/config/dbmask.php
@@ -11,6 +11,12 @@ return [
         'source' => 'mysql',
         'target' => 'mysql_materializing',
     ],
+    'materializing_lite' => [
+        'enabled' => false,
+        'source' => 'mysql',
+        'target' => 'mysql_materializing_lite',
+    ],
+
 
     'auto_include_pks' => false,
     'auto_include_timestamps' => ['created_at', 'updated_at'],

--- a/src/Console/DBMaterializeCommand.php
+++ b/src/Console/DBMaterializeCommand.php
@@ -21,7 +21,7 @@ class DBMaterializeCommand extends Command
             return;
         }
 
-        if($this->option('lite')) {
+        if($this->option('lite') || config('dbmask.materializing_lite.enabled')) {
             config(['dbmask.materializing_lite.enabled' => true]);
             $target = 'dbmask.materializing_lite.target';
         }

--- a/src/Console/DBMaterializeCommand.php
+++ b/src/Console/DBMaterializeCommand.php
@@ -12,7 +12,7 @@ class DBMaterializeCommand extends Command
 {
     use ConfirmableTrait;
 
-    protected $signature = 'db:materialize {--force : Force the operation.} {--remove : Removes all tables.}';
+    protected $signature = 'db:materialize {--force : Force the operation.} {--remove : Removes all tables.}{--lite : Doesn\'t include heavy tables}';
     protected $description = 'Generates materialized tables as specified in config/dbmask.php';
 
     public function handle(): void
@@ -21,9 +21,14 @@ class DBMaterializeCommand extends Command
             return;
         }
 
+        if($this->option('lite')) {
+            config(['dbmask.materializing_lite.enabled' => true]);
+            $target = 'dbmask.materializing_lite.target';
+        }
+
         $mask = new DBMask(
             DB::connection(config('dbmask.materializing.source') ?? DB::getDefaultConnection()),
-            DB::connection(config('dbmask.materializing.target')),
+            DB::connection(config($target ?? 'dbmask.materializing.target')),
             $this
         );
 

--- a/src/DBMask.php
+++ b/src/DBMask.php
@@ -74,7 +74,12 @@ class DBMask
             $schema = $this->target->getDatabaseName();
             $this->log("creating $targetType <fg=green>$tableName</fg=green> in schema <fg=blue>$schema</fg=blue>");
 
-            $filter = config("dbmask.table_filters.$tableName");
+            $table_filters = config('dbmask.materializing_lite.enabled')
+                ? array_merge(config("dbmask.table_filters"),config("dbmask.table_filters_lite"))
+                : config("dbmask.table_filters");
+
+
+            $filter = data_get($table_filters, $tableName);
             $create = "create $targetType $schema.$tableName ";
             $select = "select {$this->getSelectExpression($columnTransformations, $schema)} from $tableName " . ($filter ? "where $filter; " : "; ");
 


### PR DESCRIPTION
Adds lite mode to the materializing function of this project.
Lite mode adds another table_filter configuration that essentially just skips more tables when materializing resulting in a (5 times) smaller database export.

It can be used two ways:
- Enable it in the config (not recommended)
- Enable it through the '--lite' option