### PR TITLE
Add additional table filters to options

### DIFF
--- a/src/Console/DBMaterializeCommand.php
+++ b/src/Console/DBMaterializeCommand.php
@@ -12,7 +12,7 @@ class DBMaterializeCommand extends Command
 {
     use ConfirmableTrait;
 
-    protected $signature = 'db:materialize {--force : Force the operation.} {--remove : Removes all tables.}';
+    protected $signature = 'db:materialize {--force : Force the operation.} {--filter : Tables to ignore (comma separated)} {--remove : Removes all tables.}';
     protected $description = 'Generates materialized tables as specified in config/dbmask.php';
 
     public function handle(): void
@@ -25,6 +25,14 @@ class DBMaterializeCommand extends Command
             DB::connection(config('dbmask.materializing.source') ?? DB::getDefaultConnection()),
             DB::connection(config('dbmask.materializing.target')),
             $this
+        );
+
+        if($this->option('filter')) {
+            $filters = collect(explode(',', $this->option('filter') ?: []))->flip()->map(function(){ return 'false'; });
+        }
+
+        $mask->setIgnore(
+            array_merge(config('dbmask.table_filters'), $filters->toArray())
         );
 
         if ($this->option('remove')) {

--- a/src/Console/DBMaterializeCommand.php
+++ b/src/Console/DBMaterializeCommand.php
@@ -13,9 +13,9 @@ class DBMaterializeCommand extends Command
     use ConfirmableTrait;
 
     protected $signature = 'db:materialize 
-                                {--filter : Tables to ignore (comma separated)}
-                                {--source: Source database name} 
-                                {--target: Target database name}
+                                {filter?* : (array) Tables to ignore }
+                                {--source= : Source database name} 
+                                {--target= : Target database name}
                                 {--force : Force the operation.} 
                                 {--remove : Removes all tables.}';
     protected $description = 'Generates materialized tables as specified in config/dbmask.php';
@@ -32,8 +32,7 @@ class DBMaterializeCommand extends Command
             $this
         );
 
-        $filters_array = explode(',', trim($this->option('filter') ?: ''));
-        $filters = collect($filters_array)->flip()->map(function(){ return 'false'; });
+        $filters = collect($this->argument('filter') ?? [])->flip()->map(function(){ return 'false'; });
 
         $mask->setFilters(
             array_merge(config('dbmask.table_filters'), $filters->toArray())

--- a/src/DBMask.php
+++ b/src/DBMask.php
@@ -19,6 +19,9 @@ class DBMask
     /** @var Connection $target */
     protected $target;
 
+    /** @var array */
+    protected $filters = [];
+
     public function __construct(Connection $source, ?Connection $target=null, ?Command $command=null)
     {
         $this->command = $command;
@@ -74,7 +77,7 @@ class DBMask
             $schema = $this->target->getDatabaseName();
             $this->log("creating $targetType <fg=green>$tableName</fg=green> in schema <fg=blue>$schema</fg=blue>");
 
-            $filter = config("dbmask.table_filters.$tableName");
+            $filter = data_get($this->filters, $tableName);
             $create = "create $targetType $schema.$tableName ";
             $select = "select {$this->getSelectExpression($columnTransformations, $schema)} from $tableName " . ($filter ? "where $filter; " : "; ");
 
@@ -188,5 +191,10 @@ class DBMask
                 }
             });
         }
+    }
+
+    public function setFilters(array $filters) : void
+    {
+        $this->filters = $filters;
     }
 }


### PR DESCRIPTION
Adds additional table filters to the materializing function of this project.
The filter option mode adds another tables to the 'table_filters' array that essentially just skips more tables when materializing resulting in a smaller database export.

Enable it through the '--filter' option.

Example:
`php artisan db:materialize users roles permissions --target=materialized_database`
